### PR TITLE
feat: truncate text overflow with ellipsis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8977,8 +8977,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -14216,8 +14215,7 @@
     "styled-jsx": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.0.tgz",
-      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==",
-      "requires": {}
+      "integrity": "sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -183,6 +183,7 @@ const Home = (): JSX.Element => {
                   <Form.Control
                     className="form-text"
                     type="text"
+                    maxLength={30}
                     placeholder="Title (optional)"
                     name="pollTitle"
                     onChange={handlePollDetailsChange}
@@ -193,6 +194,7 @@ const Home = (): JSX.Element => {
                     className="form-text"
                     type="text"
                     name="pollDescription"
+                    maxLength={50}
                     placeholder="Description (optional)"
                     onChange={handlePollDetailsChange}
                   />
@@ -202,6 +204,7 @@ const Home = (): JSX.Element => {
                     className="form-text"
                     type="text"
                     name="pollLocation"
+                    maxLength={20}
                     placeholder="Location (optional)"
                     onChange={handlePollDetailsChange}
                   />

--- a/src/components/poll/MarkTimes.tsx
+++ b/src/components/poll/MarkTimes.tsx
@@ -54,6 +54,7 @@ const MarkTimes = (props: {
         <Form.Control
           className="poll-mark-time-name"
           type="text"
+          maxLength={30}
           placeholder="Your name"
           onChange={handleNameChange}
           autoFocus

--- a/src/styles/poll.scss
+++ b/src/styles/poll.scss
@@ -91,6 +91,9 @@
   font-size: 1.8rem;
   line-height: 1.8rem;
   font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   @include media-breakpoint-up(sm) {
     font-size: 2.8rem;
@@ -106,6 +109,9 @@
   margin-top: 0.5rem;
   margin-bottom: 1.4rem;
   line-height: 1.3rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   @include media-breakpoint-up(sm) {
     font-size: 1.5rem;
@@ -250,7 +256,10 @@
   border-top: 0 !important;
   vertical-align: middle !important;
   width: 5rem;
-  min-width: 8.3rem;
+  max-width: 8.3rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   @include media-breakpoint-up(sm) {
     font-size: 1.1rem !important;


### PR DESCRIPTION
fix #163 

Truncated poll name, poll description and the voter's names 

## Before

![Screenshot from 2022-11-28 15-51-36](https://user-images.githubusercontent.com/63963181/204256136-23adc093-3e33-484a-863d-65a944847902.png)
![Screenshot from 2022-11-28 16-00-40](https://user-images.githubusercontent.com/63963181/204256151-710f3861-b6a4-4bc5-805b-de780af5a6f0.png)

## After
![Screenshot from 2022-11-28 15-50-59](https://user-images.githubusercontent.com/63963181/204256204-d98c57fb-c2ed-4b84-a9f7-be5d8d6f79f7.png)
![Screenshot from 2022-11-28 16-00-00](https://user-images.githubusercontent.com/63963181/204256225-c32bdbb9-cf5d-4a8b-b089-077b70075c07.png)

